### PR TITLE
build: add template folder to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
 USER off:off
 COPY --chown=off:off ./app /code/app
 COPY --chown=off:off ./i18n /code/i18n
+COPY --chown=off:off ./template /code/template
 
 # format language files
 RUN find i18n -name \*.po -execdir msgfmt knowledge-panel.po -o knowledge-panel.mo \;


### PR DESCRIPTION
Fix error in production, render-to-html is in error because template is not in the docker image.