### PR TITLE
feat: now support both forms of Noun for facet

### DIFF
--- a/app/knowledge_panels.py
+++ b/app/knowledge_panels.py
@@ -5,7 +5,7 @@ from urllib.parse import urlencode
 from .config import openFoodFacts, settings
 from .exception_wrapper import no_exception
 from .i18n import translate as _
-from .models import HungerGameFilter, Taxonomies, country_to_ISO_code, facet_plural
+from .models import HungerGameFilter, Taxonomies, country_to_ISO_code, facet_plural, singularize
 from .off import data_quality, last_edit, wikidata_helper
 
 
@@ -18,9 +18,9 @@ class KnowledgePanels:
         sec_value: Union[str, None] = None,
         country: Union[str, None] = None,
     ):
-        self.facet = facet
+        self.facet = singularize(facet)
         self.value = value
-        self.sec_facet = sec_facet
+        self.sec_facet = singularize(sec_facet)
         self.sec_value = sec_value
         self.country = country
 

--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ from prometheus_fastapi_instrumentator import Instrumentator
 
 from .i18n import active_translation
 from .knowledge_panels import KnowledgePanels
-from .models import FacetName, FacetResponse, QueryData, singularize
+from .models import FacetResponse, QueryData
 from .off import global_quality_refresh
 
 tags_metadata = [
@@ -133,9 +133,9 @@ templates = Jinja2Templates(directory="template")
 @app.get("/render-to-html", tags=["Render to HTML"], response_class=HTMLResponse)
 async def render_html(
     request: Request,
-    facet_tag: FacetName = QueryData.facet_tag_query(),
+    facet_tag: str = QueryData.facet_tag_query(),
     value_tag: Optional[str] = QueryData.value_tag_query(),
-    sec_facet_tag: Optional[FacetName] = QueryData.secondary_facet_tag_query(),
+    sec_facet_tag: Optional[str] = QueryData.secondary_facet_tag_query(),
     sec_value_tag: Optional[str] = QueryData.secondary_value_tag_query(),
     lang_code: Optional[str] = QueryData.language_code_query(),
     country: Optional[str] = QueryData.country_query(),
@@ -145,9 +145,9 @@ async def render_html(
     This is helper function to make thing easier while injecting facet_kp in off-server
     """
     panels = await knowledge_panel(
-        singularize(facet_tag),
+        facet_tag,
         value_tag,
-        singularize(sec_facet_tag),
+        sec_facet_tag,
         sec_value_tag,
         lang_code,
         country,

--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ from prometheus_fastapi_instrumentator import Instrumentator
 
 from .i18n import active_translation
 from .knowledge_panels import KnowledgePanels
-from .models import FacetName, FacetResponse, QueryData
+from .models import FacetName, FacetResponse, QueryData, singularize
 from .off import global_quality_refresh
 
 tags_metadata = [
@@ -87,7 +87,7 @@ async def hello():
 
 @app.get("/knowledge_panel", tags=["knowledge-panel"], response_model=FacetResponse)
 async def knowledge_panel(
-    facet_tag: FacetName = QueryData.facet_tag_query(),
+    facet_tag: str = QueryData.facet_tag_query(),
     value_tag: Optional[str] = QueryData.value_tag_query(),
     sec_facet_tag: Optional[str] = QueryData.secondary_facet_tag_query(),
     sec_value_tag: Optional[str] = QueryData.secondary_value_tag_query(),
@@ -102,7 +102,7 @@ async def knowledge_panel(
     with active_translation(lang_code):
         # creating object that will compute knowledge panels
         obj_kp = KnowledgePanels(
-            facet=facet_tag.value,
+            facet=facet_tag,
             value=value_tag,
             sec_facet=sec_facet_tag,
             sec_value=sec_value_tag,
@@ -135,18 +135,19 @@ async def render_html(
     request: Request,
     facet_tag: FacetName = QueryData.facet_tag_query(),
     value_tag: Optional[str] = QueryData.value_tag_query(),
-    sec_facet_tag: Optional[str] = QueryData.secondary_facet_tag_query(),
+    sec_facet_tag: Optional[FacetName] = QueryData.secondary_facet_tag_query(),
     sec_value_tag: Optional[str] = QueryData.secondary_value_tag_query(),
     lang_code: Optional[str] = QueryData.language_code_query(),
     country: Optional[str] = QueryData.country_query(),
 ):
     """
     Render item.html using jinja2
+    This is helper function to make thing easier while injecting facet_kp in off-server
     """
     panels = await knowledge_panel(
-        facet_tag,
+        singularize(facet_tag),
         value_tag,
-        sec_facet_tag,
+        singularize(sec_facet_tag),
         sec_value_tag,
         lang_code,
         country,

--- a/app/models.py
+++ b/app/models.py
@@ -7,40 +7,6 @@ from fastapi import Query
 from pydantic import BaseModel, Field
 
 
-class FacetName(str, Enum):
-    country = "countries"
-    nutrition_grade = "nutrition_grades"
-    nova_group = "nova_groups"
-    brand = "brands"
-    category = "categories"
-    label = "labels"
-    packaging = "packaging"
-    origin_of_ingredient = "origins"
-    manufacturing_place = "manufacturing_places"
-    packager_code = "packager_codes"
-    ingredient = "ingredients"
-    additive = "additives"
-    vitamin = "vitamins"
-    mineral = "minerals"
-    amino_acid = "amino_acids"
-    nucleotide = "nucleotides"
-    allergen = "allergens"
-    trace = "traces"
-    language = "languages"
-    contributor = "contributors"
-    state = "states"
-    data_source = "data_sources"
-    entry_date = "entry_dates"
-    last_edit_date = "last_edit_dates"
-    last_check_date = "last_check_dates"
-    other_nutritional_substances = "other_nutritional_substances"
-    team = "teams"
-
-    @staticmethod
-    def list():
-        return [c.value for c in FacetName]
-
-
 class HungerGameFilter(str, Enum):
     label = "label"
     category = "category"

--- a/app/models.py
+++ b/app/models.py
@@ -8,33 +8,33 @@ from pydantic import BaseModel, Field
 
 
 class FacetName(str, Enum):
-    country = "country"
-    nutrition_grade = "nutrition_grade"
-    nova_group = "nova_group"
-    brand = "brand"
-    category = "category"
-    label = "label"
+    country = "countries"
+    nutrition_grade = "nutrition_grades"
+    nova_group = "nova_groups"
+    brand = "brands"
+    category = "categories"
+    label = "labels"
     packaging = "packaging"
-    origin_of_ingredient = "origin"
-    manufacturing_place = "manufacturing_place"
-    packager_code = "packager_code"
-    ingredient = "ingredient"
-    additive = "additive"
-    vitamin = "vitamin"
-    mineral = "mineral"
-    amino_acid = "amino_acid"
-    nucleotide = "nucleotide"
-    allergen = "allergen"
-    trace = "trace"
-    language = "language"
-    contributor = "contributor"
-    state = "state"
-    data_source = "data_source"
-    entry_date = "entry_date"
-    last_edit_date = "last_edit_date"
-    last_check_date = "last_check_date"
+    origin_of_ingredient = "origins"
+    manufacturing_place = "manufacturing_places"
+    packager_code = "packager_codes"
+    ingredient = "ingredients"
+    additive = "additives"
+    vitamin = "vitamins"
+    mineral = "minerals"
+    amino_acid = "amino_acids"
+    nucleotide = "nucleotides"
+    allergen = "allergens"
+    trace = "traces"
+    language = "languages"
+    contributor = "contributors"
+    state = "states"
+    data_source = "data_sources"
+    entry_date = "entry_dates"
+    last_edit_date = "last_edit_dates"
+    last_check_date = "last_check_dates"
     other_nutritional_substances = "other_nutritional_substances"
-    team = "team"
+    team = "teams"
 
     @staticmethod
     def list():
@@ -88,17 +88,24 @@ def country_to_ISO_code(value: str):
     return "world"
 
 
+inflectEngine = inflect.engine()
+
+
 def facet_plural(facet: str):
     """
-    Return plural of facet
+    Return plural form of facet
     """
-    p = inflect.engine()
-    plural = p.plural(facet)
-    facet_plural = plural
-    if facet == "packaging":
-        facet_plural = facet
+    return facet if facet == "packaging" else inflectEngine.plural_noun(facet)
 
-    return facet_plural
+
+def singularize(facet: Optional[str]):
+    """
+    Return singular form of facet
+    """
+    if facet is not None:
+        return (
+            facet if not inflectEngine.singular_noun(facet) else inflectEngine.singular_noun(facet)
+        )
 
 
 class QueryData:

--- a/tests/test_knowledge_panels.py
+++ b/tests/test_knowledge_panels.py
@@ -123,6 +123,21 @@ async def test_hunger_game_kp_label_with_value():
     }
 
 
+async def test_hunger_game_kp_label_with_value_plural_facet():
+    html = (
+        "<ul><li><p>"
+        "<a href='https://hunger.openfoodfacts.org/questions?type=label&value_tag=en%3Aorganic'>"
+        "<em>Answer robotoff questions about label en:organic</em></a></p></li></ul>"
+    )
+    result = await KnowledgePanels(facet="labels", value="en:organic").hunger_game_kp()
+    assert result == {
+        "HungerGames": {
+            "elements": [{"element_type": "text", "text_element": {"html": html}}],
+            "title_element": {"title": "Hunger games"},
+        }
+    }
+
+
 async def test_HungerGame_double_country_and_value():
     # facet country have priority
     html1 = (
@@ -403,6 +418,81 @@ async def test_data_quality_kp_with_one_facet_and_value(monkeypatch):
     }
 
 
+async def test_data_quality_kp_with_one_facet_and_value_plural_facet(monkeypatch):
+    expected_url = "https://world.openfoodfacts.org/brand/lidl/data-quality.json"
+    base_url = "https://world.openfoodfacts.org/brand/lidl/data-quality"
+    json_content = {
+        "count": 181,
+        "tags": [
+            {
+                "id": "en:ecoscore-origins-of-ingredients-origins-are-100-percent-unknown",
+                "known": 0,
+                "name": "ecoscore-origins-of-ingredients-origins-are-100-percent-unknown",
+                "products": 7898,
+                "url": (
+                    f"{base_url}/" "ecoscore-origins-of-ingredients-origins-are-100-percent-unknown"
+                ),
+            },
+            {
+                "id": "en:ecoscore-production-system-no-label",
+                "known": 0,
+                "name": "ecoscore-production-system-no-label",
+                "products": 7883,
+                "url": f"{base_url}/ecoscore-production-system-no-label",
+            },
+            {
+                "id": "en:no-packaging-data",
+                "known": 0,
+                "name": "no-packaging-data",
+                "products": 6406,
+                "url": f"{base_url}/no-packaging-data",
+            },
+        ],
+    }
+
+    monkeypatch.setattr(
+        aiohttp.ClientSession,
+        "get",
+        mock_async_get_factory(expected_url, json_content=json_content),
+    )
+    result = await KnowledgePanels(facet="brands", value="lidl").data_quality_kp()
+    first_element = result["Quality"]["elements"][0]
+    first_element["text_element"]["html"] = tidy_html(first_element["text_element"]["html"])
+    expected_text = """
+    <ul>
+        <p>The total number of issues are <b>181</b></p>
+        <li>
+            <a href="https://world.openfoodfacts.org/brand/lidl/data-quality/ecoscore-origins-of-ingredients-origins-are-100-percent-unknown">7898 products with ecoscore-origins-of-ingredients-origins-are-100-percent-unknown</a>
+        </li>
+        <li>
+            <a href="https://world.openfoodfacts.org/brand/lidl/data-quality/ecoscore-production-system-no-label">7883 products with ecoscore-production-system-no-label</a>
+        </li>
+        <li>
+            <a href="https://world.openfoodfacts.org/brand/lidl/data-quality/no-packaging-data">6406 products with no-packaging-data</a>
+        </li>
+    </ul>
+    """  # noqa: E501  # allow long lines
+    # assert html separately to have better output in case of error
+    assert first_element["text_element"]["html"] == tidy_html(expected_text)
+    # now replace it for concision of output
+    first_element["text_element"]["html"] = "ok"
+    assert result == {
+        "Quality": {
+            "elements": [
+                {
+                    "element_type": "text",
+                    "text_element": {
+                        "html": "ok",
+                        "source_text": "Data-quality issues",
+                        "source_url": "https://world.openfoodfacts.org/brand/lidl/data-quality",
+                    },
+                }
+            ],
+            "title_element": {"title": "Data-quality issues related to brand lidl"},
+        }
+    }
+
+
 async def test_data_quality_kp_with_all_tags(monkeypatch):
     expected_url = (
         "https://world.openfoodfacts.org/category/beers/brand/budweiser/data-quality.json"
@@ -515,6 +605,74 @@ async def test_last_edits_kp_with_one_facet_and_value(monkeypatch):
     )
     result = await KnowledgePanels(
         facet="vitamin", value="vitamin-k", country="hungary"
+    ).last_edits_kp()
+    first_element = result["LastEdits"]["elements"][0]
+    first_element["text_element"]["html"] = tidy_html(first_element["text_element"]["html"])
+    last_edits_text = """
+    <ul>
+        <p>Total number of edits <b>1 </b></p>
+        <li>
+            <a class="edit_entry" href="https://hu-en.openfoodfacts.org/product/0715235567418">
+                Tiqle Sticks Strawberry taste (0715235567418) edited by packbot on 2022-02-10
+            </a>
+        </li>
+    </ul>
+    """
+    # assert html separately to have better output in case of error
+    assert first_element["text_element"]["html"] == tidy_html(last_edits_text)
+    # now replace it for concision of output
+    first_element["text_element"]["html"] = "ok"
+    assert result == {
+        "LastEdits": {
+            "elements": [
+                {
+                    "element_type": "text",
+                    "text_element": {
+                        "html": "ok",
+                        "source_text": "Last-edits",
+                        "source_url": "https://hu-en.openfoodfacts.org/vitamin/vitamin-k?sort_by=last_modified_t",  # noqa: E501
+                    },
+                }
+            ],
+            "title_element": {"title": "last-edits issues related to hungary vitamin vitamin-k"},
+        }
+    }
+
+
+async def test_last_edits_kp_with_one_facet_and_value_plural_facet(monkeypatch):
+    expected_url = "https://hu-en.openfoodfacts.org/api/v2/search"
+    expected_kwargs = {
+        "params": {
+            "fields": "product_name,code,last_editor,last_edit_dates_tags",
+            "sort_by": "last_modified_t",
+            "vitamins_tags_en": "vitamin-k",
+        }
+    }
+    json_content = {
+        "count": 1,
+        "page": 1,
+        "page_count": 1,
+        "page_size": 24,
+        "products": [
+            {
+                "code": "0715235567418",
+                "last_edit_dates_tags": ["2022-02-10", "2022-02", "2022"],
+                "last_editor": "packbot",
+                "product_name": "Tiqle Sticks Strawberry taste",
+            }
+        ],
+    }
+    monkeypatch.setattr(
+        aiohttp.ClientSession,
+        "get",
+        mock_async_get_factory(
+            expected_url,
+            expected_kwargs,
+            json_content,
+        ),
+    )
+    result = await KnowledgePanels(
+        facet="vitamins", value="vitamin-k", country="hungary"
     ).last_edits_kp()
     first_element = result["LastEdits"]["elements"][0]
     first_element["text_element"]["html"] = tidy_html(first_element["text_element"]["html"])
@@ -799,6 +957,7 @@ async def test_wikidata_kp(monkeypatch):
     )
     # run the test
     result = await KnowledgePanels(facet="category", value="fr:fitou").wikidata_kp()
+    plural_result = await KnowledgePanels(facet="categories", value="fr:fitou").wikidata_kp()
     image_thumb = (
         "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d6/"
         "Paziols_%28France%29_Vue_du_village.jpg/320px-thumbnail.jpg"
@@ -836,6 +995,7 @@ async def test_wikidata_kp(monkeypatch):
     }
 
     assert result == expected_result
+    assert plural_result == expected_result
     with active_translation("it"):
         # fallbacks to english
         result_it = await KnowledgePanels(facet="category", value="fr:fitou").wikidata_kp()


### PR DESCRIPTION
### What
- To make things easier for injecting facet_kp in off-server, changed API to support both forms of Noun.
- Also removed the "FacetName" model because it has no use now.
- Added tests for it (Just copy paste :stuck_out_tongue_closed_eyes: )