### PR TITLE
ci: remove Crowdin CRON

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -5,8 +5,6 @@ on:
     #paths:
     #  - 'i18n/kp.pot'
     branches: [ 'crowdin-trigger' ]
-  schedule:
-  - cron: "0 1 * * *"
 jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What
- ci: remove Crowdin CRON
- We now use a new method which doesn't require a CRON