### PR TITLE
feat: return empty knowledge panels to crawl bots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ DOCKER_BUILDKIT=1
 DOCKER_RUN=docker-compose run --rm --no-deps facets-api
 
 
-docker_build:
+build:
 	docker-compose build
 
-docker_up:
+up:
 	docker-compose up
 
 # recompile languages files

--- a/app/knowledge_panels.py
+++ b/app/knowledge_panels.py
@@ -1,5 +1,5 @@
 import collections
-from typing import Union
+from typing import Optional, Union
 from urllib.parse import urlencode
 
 from .config import openFoodFacts, settings
@@ -31,7 +31,7 @@ class KnowledgePanels:
         self.sec_value = sec_value
         self.country = alpha2_to_country_name(country)
 
-    async def hunger_game_kp(self):
+    async def hunger_game_kp(self) -> Optional[dict]:
         query = {}
         questions_url = settings().HUNGER_GAME
         facets = {self.facet: self.value, self.sec_facet: self.sec_value}
@@ -95,7 +95,7 @@ class KnowledgePanels:
         return kp if urls else None
 
     @no_exception()
-    async def data_quality_kp(self):
+    async def data_quality_kp(self) -> dict:
         """
         Get data corresponding to differnet facet
         """
@@ -151,7 +151,7 @@ class KnowledgePanels:
         }
 
     @no_exception()
-    async def last_edits_kp(self):
+    async def last_edits_kp(self) -> dict:
         """
         Return knowledge panel for last-edits corresponding to different facet
         """
@@ -206,7 +206,7 @@ class KnowledgePanels:
         }
 
     @no_exception()
-    async def _wikidata_kp(self, facet, value):
+    async def _wikidata_kp(self, facet, value) -> Optional[dict]:
         query = {}
         if value:
             query["tagtype"] = pluralize(facet=facet)
@@ -214,7 +214,7 @@ class KnowledgePanels:
             query["tags"] = value
             return await wikidata_helper(query=query, value=value)
 
-    async def wikidata_kp(self):
+    async def wikidata_kp(self) -> Optional[dict]:
         """
         Return knowledge panel for wikidata
         """

--- a/app/main.py
+++ b/app/main.py
@@ -77,7 +77,7 @@ logger = logging.getLogger(__name__ + ".global_taxonomy_refresh")
 async def start_global_quality_refresh():
     # Clearing cache and refetching data-quality
     # Refetching data every hour
-    global_quality_refresh()
+    await global_quality_refresh()
 
 
 @app.get("/")

--- a/app/models.py
+++ b/app/models.py
@@ -125,7 +125,7 @@ class QueryData:
         query = Query(
             default=None,
             title="language code string",
-            description="To return knowledge panels in native language, defualt lang: `en`.",
+            description="To return knowledge panels in native language, default lang: `en`.",
         )
         return query
 

--- a/docs/how-to-guides/Project-setup-locally.md
+++ b/docs/how-to-guides/Project-setup-locally.md
@@ -13,7 +13,7 @@ docker-compose build
 ```
 or
 ```bash
-make docker_build
+make build
 ```
 
 to run:
@@ -22,7 +22,7 @@ docker-compose up
 ```
 or
 ```bash
-make docker_up
+make up
 ```
 
 - Visit `http://127.0.0.1/` with the endpoints or /docs for documentation

--- a/i18n/en/LC_MESSAGES/knowledge-panel.po
+++ b/i18n/en/LC_MESSAGES/knowledge-panel.po
@@ -18,16 +18,16 @@ msgstr ""
 #: app/off.py:26
 #, python-brace-format
 msgid "{products} products with {name}"
-msgstr "{products} produtos com {name}"
+msgstr ""
 
 #: app/off.py:32
 #, python-brace-format
 msgid "The total number of issues are {total_issues}"
-msgstr "O número total de problemas é {total_issues}"
+msgstr ""
 
 #: app/off.py:41
 msgid "Data-quality issues related to"
-msgstr "Problemas de qualidade de dados relacionados"
+msgstr ""
 
 #: app/off.py:42
 msgid "Data-quality issues"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -29,6 +29,19 @@ def test_hello(client):
     }
 
 
+def test_knowledge_panel_crawl_bot(client):
+    response = client.get(
+        "/knowledge_panel?facet_tag=packaging&value_tag=plastic-box",
+        headers={
+            "User-Agent": "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36 "
+            "(compatible; Googlebot/2.1; +http://www.google.com/bot.html) "
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {"knowledge_panels": {}}
+
+
 def test_knowledge_panel_no_value(client, monkeypatch):
     # we do an approximate patching, data is clearly not right, it's just to get some
     base_url = "https://world.openfoodfacts.org"


### PR DESCRIPTION
Facet knowledge panel accounts for ~7% of product opener queries.
It is likely that most facet knowledge panel queries come from web crawlers. As we don't need this information to be indexed, we return an empty dict of knowledge panels to web crawlers.