### PR TITLE
docs: add a pointer to the KP for Product Pages docs + GitHub

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -28,7 +28,11 @@ tags_metadata = [
 description = """
 Providing knowledge panels for a particular Open Food Facts facet (category, brand, etc...)
 
-A standardized way for clients to get semi-structured but generic data that they can present to users on product pages.
+A standardized way for clients to get semi-structured but generic data that they can present 
+to users on product pages.
+You can contribute at https://github.com/openfoodfacts/facets-knowledge-panels
+You should also read https://openfoodfacts.github.io/openfoodfacts-server/api/explain-knowledge-panels/ 
+for the Product Page knowledge panels which follow the same syntax (the docs provides a conceptual overview).
 """  # noqa: E501
 
 app = FastAPI(


### PR DESCRIPTION


### What
- add a pointer to the KP for Product Pages docs
- add a pointer to the KP for Facets repo
We already have a link in the other direction: https://openfoodfacts.github.io/openfoodfacts-server/reference/api-tutorials/working-with-facets/