### PR TITLE
fix: pytest warnings

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -92,7 +92,7 @@ def is_crawling_bot(request: Request):
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup
-    start_global_quality_refresh()
+    await start_global_quality_refresh()
     yield
     # Shutdown
     ...

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from contextlib import asynccontextmanager
 from typing import Annotated, Optional
 
 import asyncer
@@ -88,7 +89,16 @@ def is_crawling_bot(request: Request):
     return CRAWL_BOT_RE.search(user_agent) is not None
 
 
-@app.on_event("startup")
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Startup
+    start_global_quality_refresh()
+    yield
+    # Shutdown
+    ...
+
+app = FastAPI(lifespan=lifespan)
+
 @repeat_every(seconds=3 * 60 * 60, logger=logger, wait_first=True)
 async def start_global_quality_refresh():
     # Clearing cache and refetching data-quality


### PR DESCRIPTION
replace on_event with lifespan, according to [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/)

### What
Replaced `@app.on_event("startup")` with FastAPI's new [lifespan event handler](https://fastapi.tiangolo.com/advanced/events/).
This prevents deprecation warnings and aligns with the latest FastAPI best practices.

### Fixes bug(s)
#152 

