### PR TITLE
chore: Upgrade ci pipeline

### DIFF
--- a/.github/workflows/autoblack.yml
+++ b/.github/workflows/autoblack.yml
@@ -1,5 +1,3 @@
-
-
 # GitHub Action that uses Black to reformat the Python code in an incoming pull request.
 # If all Python code in the pull request is compliant with Black then this Action does nothing.
 # Otherwise, Black is run and its changes are committed back to the incoming pull request.
@@ -11,13 +9,13 @@ jobs:
   black:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.12
       - name: Install Black
-        run: pip install black==21.12b0 click==7.1.2
+        run: pip install black==25.1.0 click==8.1.8
       - name: Run black --check .
         run: black --check .
       - name: If needed, commit black changes to the pull request

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
@@ -26,7 +26,7 @@ jobs:
       
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       # Override language selection by uncommenting this and choosing your languages
       # with:
       #   languages: go, javascript, csharp, python, cpp, java
@@ -34,7 +34,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -48,4 +48,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -12,18 +12,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 1
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v3
       with:
-        version: v0.6.0
+        version: v0.21.2
         buildkitd-flags: --debug
 
     - name: Login to DockerHub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -31,7 +31,7 @@ jobs:
 
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@v3
+      uses: docker/metadata-action@v5
       with:
         images: |
           ghcr.io/${{ github.repository }}
@@ -42,7 +42,7 @@ jobs:
           type=sha,format=long
 
     - name: Build and push
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v6
       with:
         context: .
         push: true

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: crowdin action
-      uses: crowdin/github-action@1.4.10
+      uses: crowdin/github-action@v2
       with:
         upload_translations: true # default is false
         # Use this option to upload translations for a single specified language

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+        uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Install mkdocs requirements

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -17,6 +17,7 @@ jobs:
       pull-requests: write
 
     steps:
+    - uses: actions/checkout@v4
     - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,12 +13,12 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: build docker
         run: |
           export USER_UID=$(id -u)
           export USER_GID=$(id -g)
-          DOCKER_BUILDKIT=1 docker-compose build
+          DOCKER_BUILDKIT=1 docker compose build
       - name: build languages
         run: make build_lang
       - name: Make checks

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -12,6 +12,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v4
+      - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 ARG USER_UID=1000
 ARG USER_GID=1000
 
-FROM python:3.11
+FROM python:3.12
 
 # install gettext-tools
 RUN apt-get update && apt-get -y install gettext

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,15 @@
 
 # buildkit is more efficient
 DOCKER_BUILDKIT=1
-DOCKER_RUN=docker-compose run --rm --no-deps facets-api
+DOCKER_COMPOSE=docker compose
+DOCKER_RUN=${DOCKER_COMPOSE} run --rm --no-deps facets-api
 
 
 build:
-	docker-compose build
+	${DOCKER_COMPOSE} build
 
 up:
-	docker-compose up
+	${DOCKER_COMPOSE} up
 
 # recompile languages files
 build_lang:

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -1,5 +1,4 @@
-"""i18n handling
-"""
+"""i18n handling"""
 
 import contextlib
 import contextvars

--- a/app/main.py
+++ b/app/main.py
@@ -25,15 +25,17 @@ tags_metadata = [
         "description": "Render html based on knowledge panels.",
     },
 ]
-description = """
-Providing knowledge panels for a particular Open Food Facts facet (category, brand, etc...)
-
-A standardized way for clients to get semi-structured but generic data that they can present 
-to users on product pages.
-You can contribute at https://github.com/openfoodfacts/facets-knowledge-panels
-You should also read https://openfoodfacts.github.io/openfoodfacts-server/api/explain-knowledge-panels/ 
-for the Product Page knowledge panels which follow the same syntax (the docs provides a conceptual overview).
-"""  # noqa: E501
+description = (
+    "Providing knowledge panels for a particular Open Food Facts facet "
+    "(category, brand, etc...)\n\n"
+    "A standardized way for clients to get semi-structured "
+    "but generic data that they can present to users on product pages.\n"
+    "You can contribute at https://github.com/openfoodfacts/facets-knowledge-panels\n"
+    "You should also read "
+    "https://openfoodfacts.github.io/openfoodfacts-server/api/explain-knowledge-panels/ "
+    "for the Product Page knowledge panels "
+    "which follow the same syntax (the docs provides a conceptual overview)."
+)  # noqa: E501
 
 app = FastAPI(
     title="Open Food Facts knowledge Panels API",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   facets-api:
     image: ghcr.io/openfoodfacts/facets-knowledge-panels:${TAG:-dev}

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   facets-api:
     build:

--- a/docker/prod.yml
+++ b/docker/prod.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   facets-api:
     environment:

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ openfoodfacts==0.1.5
 prometheus-fastapi-instrumentator==6.1.0
 
 # dev
-black==24.3.0
+black==25.1.0
 pytest==7.4.0
 pytest-mock==3.11.1
 pytest-asyncio==0.21.1


### PR DESCRIPTION
### What
- upgrade actions used in Github workflow
- upgrade python version from 3.11 to 3.12 (in Dockerfile) and 3.7 to 3.12 (in workflow)
- replace `docker-compose` with `docker compose`
- remove obsolete `version` in dockerfile

### Screenshot
I have test these workflow in my fork repo, see https://github.com/SmilingPixel/facets-knowledge-panels/pull/2

### Fixes bug(s)
fixes #154 

