### PR TITLE
ci: Upgrade the CI pipeline to use docker compose and Python 3.11

### DIFF
--- a/.github/workflows/autoblack.yml
+++ b/.github/workflows/autoblack.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.7
+      - name: Set up Python 3.11
         uses: actions/setup-python@v3
         with:
-          python-version: 3.7
+          python-version: 3.11
       - name: Install Black
         run: pip install black==21.12b0 click==7.1.2
       - name: Run black --check .

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 1
 

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -160,7 +160,7 @@ jobs:
         script_stop: false
         script: |
           cd ${{ matrix.env }}
-          docker-compose up -d --remove-orphans 2>&1
+          docker compose up -d --remove-orphans 2>&1
 
     - name: Check services are up
       uses: appleboy/ssh-action@master
@@ -177,8 +177,8 @@ jobs:
         script: |
           cd ${{ matrix.env }}
           exit_code=0
-          for service in `docker-compose config  --service | tr '\n' ' '`; do
-            if [ -z `docker-compose ps -q $service` ] || [ -z `docker ps -q --no-trunc | grep $(docker-compose ${{ env.compose_args }} ps -q $service)` ]; then
+          for service in `docker compose config  --service | tr '\n' ' '`; do
+            if [ -z `docker compose ps -q $service` ] || [ -z `docker ps -q --no-trunc | grep $(docker compose ${{ env.compose_args }} ps -q $service)` ]; then
               echo "$service: DOWN"
               exit_code=1
             else

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+        uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.x
+          python-version: 3.11
       - name: Install mkdocs requirements
         run: |
           pip install mkdocs-material

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           export USER_UID=$(id -u)
           export USER_GID=$(id -g)
-          DOCKER_BUILDKIT=1 docker-compose build
+          DOCKER_BUILDKIT=1 docker compose build
       - name: build languages
         run: make build_lang
       - name: Make checks

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   facets-api:
     image: ghcr.io/openfoodfacts/facets-knowledge-panels:${TAG:-dev}

--- a/docker/dev.yml
+++ b/docker/dev.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   facets-api:
     build:


### PR DESCRIPTION
### **What’s Changed**

1. Updated the CI pipeline to use the latest versions of Docker and Python.
2. Replaced docker-compose with docker compose to align with the latest Docker changes.
3. Upgraded Python from 3.7 to 3.11 in the CI workflow.
4. Updated GitHub Actions to newer versions (checkout@v3, setup-python@v4).

### **Changes Overview**

**container-build.yml**
Switched from actions/checkout@v2 to actions/checkout@v3.

**container-deploy.yml**
Replaced all docker-compose commands with docker compose.

**generate-docs.yml**
Upgraded actions/setup-python@v2 to actions/setup-python@v4.
Changed Python version from 3.x to 3.11.

**pull_request.yml**
Updated docker-compose build to docker compose build.

### **Why?**
1. Support for docker-compose as a standalone command is being deprecated.
2. Python 3.7 is outdated, so upgrading to 3.11 ensures better compatibility and performance.
3. Keeping GitHub Actions up to date helps avoid potential workflow issues.

### **Fixes**
Resolves #154 related to CI pipeline updates.

### **Testing**

1. Verified that all .yml changes are valid.
2. Ensured compatibility with newer Docker and Python versions.

