### PR TITLE
fix: Fix CI workflow to skip add-to-project actions on forks

### DIFF
--- a/.github/workflows/github-projects.yml
+++ b/.github/workflows/github-projects.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   add-to-project:
     name: Add issue to project
-    if: github.actor != 'dependabot[bot]'
+    if: ${{ github.repository == 'openfoodfacts/knowledge-panels' && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@main
@@ -22,6 +22,7 @@ jobs:
           label-operator: AND
   add-to-design-project:
     name: 🎨 Add issue to the openfoodfacts-design project
+    if: ${{ github.repository == 'openfoodfacts/knowledge-panels' && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@main

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -10,7 +10,6 @@ on: [pull_request]
 
 jobs:
   label:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -18,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/labeler@v4
+    - name: Run Labeler
+      if: github.repository == 'openfoodfacts/knowledge-panels'
+      uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR fixes issue #162 by ensuring that the add-to-project jobs only run in the main repository (openfoodfacts/knowledge-panels) and not in forks. This prevents token access errors when running GitHub Actions on forked repositories.