### PR TITLE
fix: Permissions for .github/workflows/release-please.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v3
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/facets-knowledge-panels/security/code-scanning/12](https://github.com/openfoodfacts/facets-knowledge-panels/security/code-scanning/12)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's purpose (running the `release-please` action), it likely needs read access to repository contents and write access to pull requests. 

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`release-please`) to limit permissions to that job only. In this case, adding it at the job level is more precise.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
