### PR TITLE
fix: Permissions for .github/workflows/semantic-pr.yml

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -11,6 +11,9 @@ jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/facets-knowledge-panels/security/code-scanning/13](https://github.com/openfoodfacts/facets-knowledge-panels/security/code-scanning/13)

The best way to fix this problem is to explicitly set the `permissions` key in the workflow or job definition to restrict the GITHUB_TOKEN to only the minimum necessary privileges. In this case, since the job is only validating PR titles, it likely requires read access to `contents` and may need write access to `pull-requests` to potentially comment or mark PRs. Add a `permissions` block either at the workflow root (global for all jobs) or just under the `main` job. For clarity, add it inside the `main` job (line 13), specifying:
```yaml
permissions:
  contents: read
  pull-requests: write
```
Edit `.github/workflows/semantic-pr.yml` by inserting this block with proper indentation directly within the `main` job, before its steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
