### PR TITLE
fix: Permissions for .github/workflows/github-projects.yml

### DIFF
--- a/.github/workflows/github-projects.yml
+++ b/.github/workflows/github-projects.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Add bugs to the relevant GitHub projects
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/facets-knowledge-panels/security/code-scanning/11](https://github.com/openfoodfacts/facets-knowledge-panels/security/code-scanning/11)

**General fix:**  
Explicitly specify a minimal `permissions:` block, either at the workflow level (applies to all jobs) or at the job level. According to best practices, you should grant only the permissions absolutely required by the steps in the workflow. Since this workflow mainly adds issues and PRs to GitHub Projects, which typically requires interacting with issues or PRs, but authentication is provided via a PAT, we can safely restrict the GITHUB_TOKEN to read-only permissions on repository contents.

**Detailed fix:**  
Add the following block at the very top level of the workflow, just after the `name:` and before `on:`:
```yaml
permissions:
  contents: read
```
This restricts the GITHUB_TOKEN to read-only access to repository contents for the entire workflow, following least-privilege principles. If in the future a step requiring additional permissions is added, this can be revisited.

**Which files/lines to change:**  
Edit `.github/workflows/github-projects.yml`. Insert the `permissions:` block (as above) after line 1, before line 3.

**Methods/imports/definitions needed:**  
No imports/definitions are needed for a workflow permissions block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
