### PR TITLE
fix: Permissions for .github/workflows/pull_request.yml

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   # quality
   quality_checks:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/facets-knowledge-panels/security/code-scanning/10](https://github.com/openfoodfacts/facets-knowledge-panels/security/code-scanning/10)

To resolve this issue, you should add a `permissions` block specifying the least privileged scope needed for the job. In this case, the job only requires read-access to repository contents for checking out code and running tests. You should insert a `permissions` block at the appropriate level:
- If you want all jobs in the workflow to have these permissions, add the block at the root just after the workflow `name` or `on` block.
- If only the `quality_checks` job should have these permissions, add it under `quality_checks`.

For maximum clarity and maintainability, setting it at the job level is safest if you anticipate needing different permissions for other jobs in the future. Here, we will add it beneath `quality_checks:` before `runs-on: ubuntu-latest`.

No additional imports, definitions, or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
