### PR TITLE
fix: Permissions for .github/workflows/merge-conflict-autolabel.yml

### DIFF
--- a/.github/workflows/merge-conflict-autolabel.yml
+++ b/.github/workflows/merge-conflict-autolabel.yml
@@ -1,3 +1,5 @@
+permissions:
+  pull-requests: write
 name: '💥 Auto-Label Merge Conflicts on PRs'
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/facets-knowledge-panels/security/code-scanning/9](https://github.com/openfoodfacts/facets-knowledge-panels/security/code-scanning/9)

The fix is to explicitly declare a `permissions:` block in the workflow to adhere to the principle of least privilege. The action used labels pull requests when merge conflicts are detected, so (per GitHub documentation) the minimum required permission is `pull-requests: write`. If, for some reason, the action needs to read repository contents, then `contents: read` can also be supplied, but the minimum for labeling pull requests is just `pull-requests: write`. Insert the following block near the top (either at the workflow root, for all jobs, or directly under the relevant job).

Since there is only one job, it is simplest to put the `permissions:` block at the root for clarity and extensibility. This requires adding (for example):

```yaml
permissions:
  pull-requests: write
```

immediately after the `name:` and before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
