### PR TITLE
fix: Permissions for generate-docs.yml

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -3,6 +3,8 @@
 #----------------------------------------------
 
 name: Generate documentation
+permissions:
+  contents: write
 on:
   pull_request:
     # on pull request we just want to build to see nothing is broken


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/facets-knowledge-panels/security/code-scanning/8](https://github.com/openfoodfacts/facets-knowledge-panels/security/code-scanning/8)

To resolve this issue, explicitly set the `permissions` block in the workflow. The best place to do this for a single-job workflow is at the root level, but it may also be set at the job level if different permissions are needed for different jobs. In this case, since the job includes steps that require writing to repository contents (deployment), the minimal required permission is `contents: write`. No other permissions are needed based on the workflow's steps. Add the following block after the workflow's `name:` declaration (line 5) and before the `on:` block (line 6), unless there are root-level permissions already present. No imports or additional definitions are required for YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
