### PR TITLE
fix: Permissions for crowdin.yml

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,5 +1,9 @@
 name: Crowdin Action
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   push:
     #paths:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/facets-knowledge-panels/security/code-scanning/7](https://github.com/openfoodfacts/facets-knowledge-panels/security/code-scanning/7)

To fix this problem, you should add a `permissions` key to the workflow YAML file. For maximum clarity and security, add it at the top level, just below the workflow name and event triggers. Review the steps: The workflow uses Crowdin to download/upload translations, and then creates pull requests. According to Crowdin Action documentation and general GitHub Actions usage, it needs ability to read code and create pull requests but does not need full write access to code or issues. Therefore, set `contents: read` (so workflow jobs can read source and translation files) and `pull-requests: write` (to allow PR creation).

Edit `.github/workflows/crowdin.yml`, adding:
```yaml
permissions:
  contents: read
  pull-requests: write
```
just after the workflow name and before `on:` or after `on:`.

No other code imports or steps need to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
