### PR TITLE
fix: Permissions for container-deploy.yml

### DIFF
--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Docker Compose Deployment CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/facets-knowledge-panels/security/code-scanning/6](https://github.com/openfoodfacts/facets-knowledge-panels/security/code-scanning/6)

To address the problem, explicitly declare the required least privilege permissions using the `permissions` key. This can be set at the top level (applies to all jobs) or per-job. In this workflow, setting `permissions:` at the top level is most appropriate since there is only one job, or per-job for future extensibility. Audit the job's steps: most deployment steps run remote (over SSH), wait on other workflows, or annotate external services, which do not require repository modification. At minimum, these steps likely only require read access to repository contents for proper operation; if any future steps need more privileges, they should be added specifically. 

The best fix: Insert  
```yaml
permissions:
  contents: read
```  
at the top level (line 2), directly after the workflow `name`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
